### PR TITLE
add basic styles, and page routing for generating and redeeming codes

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -1,8 +1,9 @@
 <html>
   <head>
     <meta content="text/html;charset=utf-8" http-equiv="Content-Type"/>
+    <title>backchannel</title>
   </head>
-  <body>
+  <body style="margin:0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;">
     <div id="root"> </div>
     <script type="module"> 
       // TODO: this should be part of the bundle instead and shouldn't be

--- a/package.json
+++ b/package.json
@@ -11,12 +11,14 @@
   "author": "Karissa McKelvey",
   "license": "MIT",
   "dependencies": {
+    "@emotion/react": "^11.1.5",
     "dexie": "^3.0.3",
     "enc-utils": "^3.0.0",
     "magic-wormhole": "github:okdistribute/magic-wormhole-js#browser",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "util": "^0.12.3"
+    "util": "^0.12.3",
+    "wouter": "^2.7.4"
   },
   "devDependencies": {
     "@types/node": "^14.14.39",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,94 +1,238 @@
-import React, { useState }  from 'react';
-import { copyToClipboard } from './web'
-import { Backchannel, Contact } from './backchannel'
+// this comment tells babel to convert jsx to calls to a function called jsx instead of React.createElement
+// it makes emotion work
+/** @jsx jsx */
+import React, { useState } from 'react';
+import { jsx, css } from '@emotion/react';
+import { Link, Route } from 'wouter';
 
-let dbName = "backchannel_" + window.location.hash
-console.log(dbName)
-let backchannel = new Backchannel(dbName)
+import { Backchannel, Contact } from './backchannel';
+import { copyToClipboard } from './web';
+
+let dbName = 'backchannel_' + window.location.hash;
+console.log(dbName);
+let backchannel = new Backchannel(dbName);
 
 // Amount of time to show immediate user feedback
 let USER_FEEDBACK_TIMER = 5000;
 
-const CodeView = () => {
-  let [ code , setCode ] = useState("");
-  let [ key, setKey ] = useState("");
-  let [ generated , setGenerated ] = useState(false);
-  let [ errorMsg, setErrorMsg] = useState("");
+type CodeViewMode = 'add' | 'generate';
+
+const CodeView = ({ view }: { view: CodeViewMode }) => {
+  let [code, setCode] = useState('');
+  let [key, setKey] = useState('');
+  let [message, _setMessage] = useState('');
+  let [messageTimeoutID, setMessageTimeoutID] = useState(null);
+  let [errorMsg, setErrorMsg] = useState('');
+  let [contact, setContact] = useState(null);
 
   let onError = (err: Error) => {
-    console.error('got error from backend', err)
+    console.error('got error from backend', err);
     setErrorMsg(err.message);
+  };
+
+  function handleChange(event) {
+    setErrorMsg('');
+    setCode(event.target.value);
   }
 
-  function handleChange (event) {
-    setErrorMsg("");
-    setCode(event.target.value)
-  }
-
-  async function onClickRedeem () {
-    console.log('on click redeem')
-    try { 
-      let contact = await backchannel.accept(code)
-      setErrorMsg("");
-      console.log('got a secure connection to wormhole')
-      setKey(contact.key)
-    } catch (err)  {
-      onError(err)
+  async function onClickRedeem() {
+    console.log('on click redeem');
+    try {
+      let contact = await backchannel.accept(code);
+      setErrorMsg('');
+      clearMessage(messageTimeoutID);
+      setContact(contact);
+    } catch (err) {
+      onError(err);
     }
   }
 
-  async function onClickGenerate () {
-    // When a new code is generated
-    // no news is good news.
-    setGenerated(true);
-    setErrorMsg("");
+  function clearMessage(id) {
+    console.log('clearing', id);
+
+    if (id) {
+      clearTimeout(id);
+    }
+  }
+
+  function setMessage(message: string) {
+    clearMessage(messageTimeoutID); // TODO this doesn't clear, probably need to use useEffect
+
+    // Set message to be displayed
+    _setMessage(message);
 
     // Reset after a certain amount of time
-    setTimeout(() => {
-      setGenerated(false);
+    const timeoutID = setTimeout(() => {
+      setMessage('');
     }, USER_FEEDBACK_TIMER);
+    // Update new timeoutID
+    console.log('new timeout id', timeoutID);
 
-    try { 
-      let code = await backchannel.getCode()
-      console.log('code copied to clipboard', code)
-      setKey(code)
-      setErrorMsg("");
-      await copyToClipboard(code)
-      let contact = await backchannel.announce(code)
-      console.log('got a secure connection to wormhole')
-      setKey(contact.key)
+    setMessageTimeoutID(timeoutID);
+  }
+
+  async function onClickGenerate() {
+    setErrorMsg('');
+
+    try {
+      const code = await backchannel.getCode();
+
+      if (code) {
+        setKey(code);
+
+        // automatically copy to clipboad. TODO doesn't work on safari
+        const copySuccess = await copyToClipboard(code);
+        if (copySuccess) {
+          setMessage('Code copied!'); // TODO this gets called multiple times?
+        }
+
+        // This promise returns once the other party redeems the code
+        let contact = await backchannel.announce(code);
+        clearMessage(messageTimeoutID);
+        setContact(contact);
+        // contact.key is the strong key
+      }
     } catch (err) {
-      setGenerated(false);
-      onError(err)
+      onError(err);
     }
   }
 
   return (
     <div>
-      <h1>Backchannel</h1>
-      <div className="Hello">
-        <button disabled={generated} onClick={onClickGenerate}>
-            Generate
-        </button>
-
-        <input type="text" onChange={handleChange}></input>
-        <button onClick={onClickRedeem}>
-           Redeem 
-        </button>
-      </div>
+      <TopBar>
+        {view === 'add' && (
+          <React.Fragment>
+            <input
+              css={css`
+                font-size: inherit;
+                width: 10em;
+              `}
+              type="text"
+              onChange={handleChange}
+            ></input>
+            <Button onClick={onClickRedeem}>Redeem</Button>
+          </React.Fragment>
+        )}
+        {view === 'generate' && (
+          <React.Fragment>
+            <input
+              css={css`
+                font-size: inherit;
+                width: 10em;
+              `}
+              value={key}
+              readOnly
+            />
+            {key ? (
+              <Button onClick={() => copyToClipboard(code)}>Copy</Button>
+            ) : (
+              <Button onClick={onClickGenerate}>Generate</Button>
+            )}
+          </React.Fragment>
+        )}
+        <Link href="/">
+          <a
+            css={css`
+              color: white;
+              padding-left: 8px;
+              font-size: 0.8em;
+            `}
+          >
+            Cancel
+          </a>
+        </Link>
+      </TopBar>
       <div>{errorMsg}</div>
-      <div className="Code">
-        {generated && "Link copied!"}
+      {contact && contact.key && (
+        <div
+          css={css`
+            display: inline-block;
+            margin: 16px 0;
+            word-break: break-word;
+          `}
+        >
+          Connection established at {contact.key}
         </div>
-      <div className="Key">
-        {key && key} 
-      </div>
+      )}
+      {message && (
+        <div
+          css={css`
+            display: inline-block;
+            margin: 16px 0;
+            word-break: break-word;
+          `}
+        >
+          {message}
+        </div>
+      )}
     </div>
   );
 };
 
+const A = ({ children, href, ...props }) => (
+  <Link href={href} {...props}>
+    <a
+      css={css`
+        display: inline-block;
+        margin: 0 1em;
+        background: white;
+        color: black;
+        text-decoration: none;
+        padding: 2px 8px;
+        border-radius: 5px;
+      `}
+    >
+      {children}
+    </a>
+  </Link>
+);
+const Button = ({ children, ...props }) => (
+  <button
+    css={css`
+      display: inline-block;
+      margin: 0 1em;
+      background: white;
+      color: black;
+      padding: 2px 8px;
+      border-radius: 5px;
+      font-size: inherit;
+    `}
+    {...props}
+  >
+    {children}
+  </button>
+);
+
+const TopBar = (props) => (
+  <div
+    {...props}
+    css={css`
+      background: gray;
+      text-align: center;
+      padding: 16px 0;
+    `}
+  />
+);
+
 export default function App() {
   return (
-    <CodeView />
+    <div
+      css={css`
+        text-align: center;
+      `}
+    >
+      <Route path="/add">
+        <CodeView view={'add'} />
+      </Route>
+      <Route path="/generate">
+        <CodeView view={'generate'} />
+      </Route>
+      <Route path="/">
+        <TopBar>
+          <A href="add">Input code</A>
+          <A href="generate">Generate code</A>
+        </TopBar>
+      </Route>
+    </div>
   );
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,22 +3,14 @@ import { render } from 'react-dom';
 import App from './App';
 
 declare global {
-  interface Window { 
-    spake2: any
+  interface Window {
+    spake2: any;
   }
 }
 
-function onError (err: Error) {
-  console.error("Connection error")
-  console.error(err)
+function onError(err: Error) {
+  console.error('Connection error');
+  console.error(err);
 }
 
-console.log('hello world')
-var el = document.createElement('div')
-el.setAttribute('id', 'root')
-document.body.appendChild(el)
-
-render(
-  <App />, 
-  document.getElementById('root')
-);
+render(<App />, document.getElementById('root'));

--- a/src/web.tsx
+++ b/src/web.tsx
@@ -1,14 +1,16 @@
 import type { Code } from './wormhole';
 
 /**
- * Utilities for common tasks specific to the browser 
+ * Utilities for common tasks specific to the browser
  */
 
-export async function copyToClipboard (code: Code) {
+export async function copyToClipboard(code: Code): Promise<boolean> {
   try {
     await navigator.clipboard.writeText(code);
     console.log('Code copied to clipboard');
+    return true;
   } catch (err) {
     console.error('Failed to copy: ', err);
+    return false;
   }
 }


### PR DESCRIPTION
https://user-images.githubusercontent.com/1589186/115668620-2cae2280-a2fc-11eb-82ad-f50c2a81bbc8.mov

* added the `emotion` package to write css directly into jsx components
* applied linter to client-side files (it may be best to read this PR with "ignore whitespace" option enabled)
* simple routing: creates urls for the "redeem code" and "generate code" views, and a cancel button to escape back to the main view.
* known issue: you have to start the app at the root url `/` (need to configure backend to correctly route the other urls to their corresponding views)