### PR TITLE
Show a placeholder when contact has no nickname

### DIFF
--- a/src/components/ContactList.tsx
+++ b/src/components/ContactList.tsx
@@ -7,7 +7,7 @@ import { color, fontSize } from './tokens';
 import { IMessage } from '../backend/types';
 import Automerge from 'automerge';
 import { Mailbox } from '../backend/backchannel';
-import { timestampToDate } from './util';
+import { timestampToDate, Nickname } from './util';
 import {
   BottomNav,
   Button,
@@ -235,17 +235,7 @@ export default function ContactList(props) {
                           font-size: ${fontSize[2]};
                         `}
                       >
-                        {contact.avatar ? (
-                          <img
-                            alt={`nickname for contact ${contact.id}`}
-                            css={css`
-                              max-width: 200px;
-                            `}
-                            src={contact.avatar}
-                          />
-                        ) : (
-                          contact?.moniker
-                        )}
+                        <Nickname contact={contact} />
                       </div>
                       <div
                         css={css`

--- a/src/components/ContactSettings.tsx
+++ b/src/components/ContactSettings.tsx
@@ -5,6 +5,7 @@ import { useLocation } from 'wouter';
 
 import { Button, TopBar, UnderlineInput, SettingsContent } from '.';
 import { Page, ContentWithTopNav } from './';
+import { Nickname } from './util';
 import Backchannel from '../backend';
 import { IContact, ContactId } from '../backend/types';
 
@@ -57,7 +58,10 @@ export default function ContactSettings(props: Props) {
 
   return (
     <Page align="center">
-      <TopBar title={contact.moniker} backHref={`/mailbox/${contact.id}`} />
+      <TopBar
+        title={<Nickname contact={contact} />}
+        backHref={`/mailbox/${contact.id}`}
+      />
       <ContentWithTopNav>
         <SettingsContent
           css={css`

--- a/src/components/Mailbox.tsx
+++ b/src/components/Mailbox.tsx
@@ -12,7 +12,7 @@ import {
 import { Button, Spinner, TopBar, UnderlineInput } from './';
 import Backchannel, { EVENTS } from '../backend';
 import { color, fontSize } from './tokens';
-import { timestampToDate } from './util';
+import { timestampToDate, Nickname } from './util';
 import { Instructions } from '../components';
 import { FileProgress } from '../backend/blobs';
 import { ReactComponent as Dots } from '../components/icons/Dots.svg';
@@ -39,8 +39,7 @@ export default function Mailbox(props: Props) {
   );
   let [progress, setProgress] = useState({});
   const [isDragging, setIsDragging] = useState(false);
-  //eslint-disable-next-line
-  const [_, setLocation] = useLocation();
+  const [, setLocation] = useLocation();
   const bottomRef = useRef(null);
 
   const scrollToBottom = () => {
@@ -212,17 +211,7 @@ export default function Mailbox(props: Props) {
                 connected ? StatusType.CONNECTED : StatusType.DISCONNECTED
               }
             />
-            {contact.avatar ? (
-              <img
-                alt={`nickname for contact ${contact.id}`}
-                css={css`
-                  max-width: 200px;
-                `}
-                src={contact.avatar}
-              />
-            ) : (
-              contact?.moniker
-            )}
+            <Nickname contact={contact} />
           </div>
         }
         icon={

--- a/src/components/util.ts
+++ b/src/components/util.ts
@@ -1,4 +1,0 @@
-export function timestampToDate(timestamp: string): string {
-  const date = new Date(parseInt(timestamp));
-  return date.toLocaleDateString();
-}

--- a/src/components/util.tsx
+++ b/src/components/util.tsx
@@ -1,0 +1,40 @@
+/** @jsxImportSource @emotion/react */
+import React from 'react';
+import { css } from '@emotion/react/macro';
+import { IContact } from '../backend/types';
+import { color } from './tokens';
+
+export function timestampToDate(timestamp: string): string {
+  const date = new Date(parseInt(timestamp));
+  return date.toLocaleDateString();
+}
+
+export function Nickname({ contact }: { contact: IContact }) {
+  if (contact.avatar) {
+    return (
+      <img
+        alt={`nickname for contact ${contact.id}`}
+        css={css`
+          max-width: 200px;
+        `}
+        src={contact.avatar}
+      />
+    );
+  }
+
+  if (contact.moniker) {
+    return <>contact.moniker</>;
+  }
+
+  // No nickname was ever assigned, show placeholder
+  return (
+    <span
+      css={css`
+        color: ${color.textSecondary};
+        font-style: italic;
+      `}
+    >
+      No name
+    </span>
+  );
+}


### PR DESCRIPTION
It's possible for a contact to end up with no nickname (if the user quits the "Confirm Nickname" page altogether), so show a placeholder in that case:

![placeholder in contact list](https://user-images.githubusercontent.com/1589186/123161168-eff9c700-d423-11eb-82b3-a35cbde935eb.png) ![placeholder in chat thread](https://user-images.githubusercontent.com/1589186/123161172-f0925d80-d423-11eb-8575-aa9d86ea5f4b.png)
