### PR TITLE
Fix contact settings page

### DIFF
--- a/src/components/ContactSettings.tsx
+++ b/src/components/ContactSettings.tsx
@@ -1,13 +1,16 @@
 /** @jsxImportSource @emotion/react */
 import React, { useState } from 'react';
-import { css } from '@emotion/react/macro';
+import { Link } from 'wouter';
 import { useLocation } from 'wouter';
 
-import { Button, TopBar, UnderlineInput, SettingsContent } from '.';
-import { Page, ContentWithTopNav } from './';
-import { Nickname } from './util';
+import { TopBar, SettingsContent } from '.';
+import { Page, ContentWithTopNav, IconButton } from './';
+import TopBarNickname from './TopBarNickname';
 import Backchannel from '../backend';
 import { IContact, ContactId } from '../backend/types';
+import { ReactComponent as PersonSmall } from '../components/icons/PersonSmall.svg';
+import { ReactComponent as HatPerson } from '../components/icons/HatPerson.svg';
+import { ReactComponent as ExportSmall } from '../components/icons/ExportSmall.svg';
 
 let backchannel = Backchannel();
 
@@ -16,33 +19,10 @@ type Props = {
 };
 
 export default function ContactSettings(props: Props) {
-  const [contact, setContact] = useState<IContact>(
+  const [contact] = useState<IContact>(
     backchannel.db.getContactById(props.contactId)
   );
-  const [nickname, setNickname] = useState<string>();
-  //eslint-disable-next-line
-  let [_, setLocation] = useLocation();
-
-  async function updateNickname(e) {
-    e.preventDefault();
-    try {
-      const updatedContact = await backchannel.editMoniker(
-        contact.id,
-        nickname
-      );
-      setContact(updatedContact);
-    } catch (err) {
-      onError(err);
-    }
-  }
-
-  const onError = (err: Error) => {
-    console.error('got error from backend', err);
-  };
-
-  function handleChange(e) {
-    setNickname(e.target.value);
-  }
+  let [, setLocation] = useLocation();
 
   async function handleContactDelete(e) {
     e.preventDefault();
@@ -59,29 +39,24 @@ export default function ContactSettings(props: Props) {
   return (
     <Page align="center">
       <TopBar
-        title={<Nickname contact={contact} />}
+        title={<TopBarNickname contact={contact} hideIndicator />}
         backHref={`/mailbox/${contact.id}`}
       />
       <ContentWithTopNav>
-        <SettingsContent
-          css={css`
-            max-width: unset;
-          `}
-        >
-          <form id="contact-info">
-            <UnderlineInput
-              onChange={handleChange}
-              defaultValue={contact.moniker}
-              placeholder="Contact nickname"
-              autoFocus
-            />
-          </form>
-          <Button type="submit" onClick={updateNickname} form="contact-info">
-            Save
-          </Button>
-          <Button onClick={handleContactDelete} variant="destructive">
+        <SettingsContent>
+          <Link href={`/contact/${contact?.id}/edit`}>
+            <IconButton icon={HatPerson}>Edit Nickname</IconButton>
+          </Link>
+          <IconButton
+            onClick={handleContactDelete}
+            variant="destructive"
+            icon={PersonSmall}
+          >
             Delete Contact
-          </Button>
+          </IconButton>
+          <IconButton disabled variant="transparent" icon={ExportSmall}>
+            Export message history
+          </IconButton>
         </SettingsContent>
       </ContentWithTopNav>
     </Page>

--- a/src/components/Mailbox.tsx
+++ b/src/components/Mailbox.tsx
@@ -12,13 +12,13 @@ import {
 import { Button, Spinner, TopBar, UnderlineInput } from './';
 import Backchannel, { EVENTS } from '../backend';
 import { color, fontSize } from './tokens';
-import { timestampToDate, Nickname } from './util';
-import { Instructions } from '../components';
+import { timestampToDate } from './util';
+import { Instructions } from '.';
 import { FileProgress } from '../backend/blobs';
-import { ReactComponent as Dots } from '../components/icons/Dots.svg';
-import { ReactComponent as Paperclip } from '../components/icons/Paperclip.svg';
-import { ReactComponent as Paperplane } from '../components/icons/Paperplane.svg';
-import IndicatorDot, { StatusType } from './IndicatorDot';
+import { ReactComponent as Dots } from './icons/Dots.svg';
+import { ReactComponent as Paperclip } from './icons/Paperclip.svg';
+import { ReactComponent as Paperplane } from './icons/Paperplane.svg';
+import TopBarNickname from './TopBarNickname';
 
 let backchannel = Backchannel();
 const PADDING_CHAT = 12;
@@ -195,28 +195,8 @@ export default function Mailbox(props: Props) {
       onDrop={handleDrop}
     >
       <TopBar
-        title={
-          <div
-            css={css`
-              display: flex;
-              flex-direction: row;
-              align-items: center;
-            `}
-          >
-            <IndicatorDot
-              css={css`
-                margin-right: 6px;
-              `}
-              status={
-                connected ? StatusType.CONNECTED : StatusType.DISCONNECTED
-              }
-            />
-            <Nickname contact={contact} />
-          </div>
-        }
-        icon={
-          <Dots onClick={() => setLocation(`/contact/${contact?.id}/edit`)} />
-        }
+        title={<TopBarNickname contact={contact} connected={connected} />}
+        icon={<Dots onClick={() => setLocation(`/contact/${contact?.id}`)} />}
       />
       <div
         css={css`

--- a/src/components/TopBarNickname.tsx
+++ b/src/components/TopBarNickname.tsx
@@ -1,0 +1,40 @@
+/** @jsxImportSource @emotion/react */
+import React from 'react';
+import { css } from '@emotion/react/macro';
+import IndicatorDot, { StatusType } from './IndicatorDot';
+import { Nickname } from './util';
+
+import { IContact } from '../backend/types';
+
+type Props = {
+  connected?: boolean;
+  contact: IContact;
+  hideIndicator?: boolean;
+};
+
+export default function TopBarNickname({
+  connected = false,
+  contact,
+  hideIndicator = false,
+}: Props) {
+  return (
+    <>
+      <div
+        css={css`
+          display: flex;
+          flex-direction: row;
+          align-items: center;
+        `}
+      >
+        <IndicatorDot
+          css={css`
+            margin-right: 6px;
+            opacity: ${hideIndicator ? 0 : 1};
+          `}
+          status={connected ? StatusType.CONNECTED : StatusType.DISCONNECTED}
+        />
+        <Nickname contact={contact} />
+      </div>
+    </>
+  );
+}

--- a/src/components/icons/PersonSmall.svg
+++ b/src/components/icons/PersonSmall.svg
@@ -1,0 +1,4 @@
+<svg width="14" height="18" viewBox="0 0 14 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="6.60835" cy="4.09273" r="3.09273" stroke="currentColor" stroke-width="2"/>
+<path d="M1 15.5078C1 12.4088 3.51228 9.89648 6.61133 9.89648C9.71038 9.89648 12.2227 12.4088 12.2227 15.5078V16.0819H1V15.5078Z" stroke="currentColor" stroke-width="2"/>
+</svg>

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -49,7 +49,6 @@ export function TopBar({
         <div
           css={css`
             width: 50px;
-            height: 50px;
             cursor: pointer;
 
             display: flex;

--- a/src/components/util.tsx
+++ b/src/components/util.tsx
@@ -23,7 +23,7 @@ export function Nickname({ contact }: { contact: IContact }) {
   }
 
   if (contact.moniker) {
-    return <>contact.moniker</>;
+    return <>{contact.moniker}</>;
   }
 
   // No nickname was ever assigned, show placeholder


### PR DESCRIPTION
Click the three dots menu in a mailbox thread brings up the contact settings page, which gives options to edit or delete the contact: 

![Contact settings page](https://user-images.githubusercontent.com/1589186/123169773-9054e900-d42e-11eb-8ed7-2eb32636f66a.png)

Deviating somewhat from the designs because I didn't want to introduce a new pattern (dropdown menu), whereas we have routed settings pages already in the app.

Demo:

https://user-images.githubusercontent.com/1589186/123169926-c1351e00-d42e-11eb-9513-ffbc517a0223.mov


