### PR TITLE
Remove navigation button from animation screens

### DIFF
--- a/src/components/CodeView.tsx
+++ b/src/components/CodeView.tsx
@@ -97,6 +97,7 @@ export function codeViewAnimation(animationMode: AnimationMode) {
       // Show connection loading page
       return (
         <CodeView
+          backHref={null}
           content={<IconWithMessage icon={Spinner} text="Connecting" />}
         />
       );
@@ -105,6 +106,7 @@ export function codeViewAnimation(animationMode: AnimationMode) {
       // Show successful connection message
       return (
         <CodeView
+          backHref={null}
           content={
             <IconWithMessage icon={Checkmark} text="Correspondent found" />
           }
@@ -114,6 +116,7 @@ export function codeViewAnimation(animationMode: AnimationMode) {
     case AnimationMode.CreatingChannel:
       return (
         <CodeView
+          backHref={null}
           content={
             <IconWithMessage icon={Spinner} text="Creating Secure Channel" />
           }


### PR DESCRIPTION
The PR to remove the back button from the "Confirm nickname" page #121 reminds me that the "Contact found/creating secure channel" animation screens should probably not have back buttons either: 

![Contact found animation](https://user-images.githubusercontent.com/1589186/123170655-a020fd00-d42f-11eb-8438-7ff22e11b9e9.png)
