### PR TITLE
Add icons to settings pages buttons

### DIFF
--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -1,5 +1,6 @@
 /** @jsxImportSource @emotion/react */
 import React, { useState } from 'react';
+import { css } from '@emotion/react/macro';
 import { Link } from 'wouter';
 
 import config from '../backend/config';
@@ -10,6 +11,7 @@ import {
   UnderlineInput,
   SettingsContent,
   IconButton,
+  BottomActions,
 } from '.';
 import * as storage from './storage';
 import { Page, ContentWithTopNav } from './';
@@ -18,6 +20,11 @@ import { ReactComponent as PlusSmall } from '../components/icons/PlusSmall.svg';
 import { ReactComponent as EnvelopeSmall } from '../components/icons/EnvelopeSmall.svg';
 import { ReactComponent as CloudCrossedSmall } from '../components/icons/CloudCrossedSmall.svg';
 import { ReactComponent as ExportSmall } from '../components/icons/ExportSmall.svg';
+import { ReactComponent as CloudCycleSmall } from '../components/icons/CloudCycleSmall.svg';
+import { ReactComponent as RelaySmall } from '../components/icons/RelaySmall.svg';
+import { ReactComponent as TrashSmall } from '../components/icons/TrashSmall.svg';
+import { ReactComponent as Checkmark } from '../components/icons/Checkmark.svg';
+import { ReactComponent as CycleSmall } from '../components/icons/CycleSmall.svg';
 
 let backchannel = Backchannel();
 
@@ -28,17 +35,19 @@ export default function Settings() {
       <ContentWithTopNav>
         <SettingsContent>
           <Link href="/settings/devices">
-            <Button>Syncronize Devices</Button>
+            <IconButton icon={CloudCycleSmall}>Syncronize Devices</IconButton>
           </Link>
           <Link href="/settings/relay">
-            <Button>Relay URL</Button>
+            <IconButton icon={RelaySmall}>Relay URL</IconButton>
           </Link>
           <Link href="/settings/reset">
-            <Button variant="destructive">Clear all Data</Button>
+            <IconButton icon={TrashSmall} variant="destructive">
+              Clear all Data
+            </IconButton>
           </Link>
-          <Button disabled variant="transparent">
+          <IconButton icon={ExportSmall} disabled variant="transparent">
             Export message history
-          </Button>
+          </IconButton>
         </SettingsContent>
       </ContentWithTopNav>
     </Page>
@@ -79,22 +88,37 @@ export function RelaySettings() {
       <TopBar title="Relay URL" backHref="/settings" />
       <ContentWithTopNav>
         <Instructions>
-          This is Backchannel relay URL, you can also specify your own:
+          This is Backchannel relay URL,
+          <br /> you can also specify your own:
         </Instructions>
         <SettingsContent>
           <UnderlineInput
+            css={css`
+              margin: 0 24px;
+              width: unset;
+            `}
             name="relay"
             onChange={updateValues}
             defaultValue={settings.relay}
             placeholder="https://relay.yourdomain.org"
           />
-          <Button type="submit" onClick={updateSettings}>
-            Save
-          </Button>
-          <Button variant="transparent" type="submit" onClick={restoreDefault}>
-            Restore Default
-          </Button>
         </SettingsContent>
+        <BottomActions>
+          <IconButton
+            css={css`
+              margin-bottom: 18px;
+            `}
+            icon={CycleSmall}
+            variant="transparent"
+            type="submit"
+            onClick={restoreDefault}
+          >
+            Restore Default
+          </IconButton>
+          <IconButton icon={Checkmark} type="submit" onClick={updateSettings}>
+            Save
+          </IconButton>
+        </BottomActions>
       </ContentWithTopNav>
     </Page>
   );
@@ -137,7 +161,7 @@ export function ClearAllSettings() {
 export function DevicesSettings() {
   return (
     <Page align="center">
-      <TopBar title="Synchronise devices" />
+      <TopBar title="Synchronise devices" backHref="/settings" />
       <ContentWithTopNav>
         <SettingsContent>
           <Link href="/devices/generate">

--- a/src/components/icons/Checkmark.svg
+++ b/src/components/icons/Checkmark.svg
@@ -1,3 +1,3 @@
 <svg width="28" height="28" viewBox="0 0 28 25" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M2 13.25L12.2 22L26 2" stroke="white" stroke-width="4"/>
+<path d="M2 13.25L12.2 22L26 2" stroke="currentColor" stroke-width="4"/>
 </svg>

--- a/src/components/icons/CycleSmall.svg
+++ b/src/components/icons/CycleSmall.svg
@@ -1,0 +1,4 @@
+<svg width="17" height="15" viewBox="0 0 17 15" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M7.00106 1.99805C3.68677 1.99805 1 4.68481 1 7.99911C1 11.3134 3.68677 14.0002 7.00106 14.0002C10.3154 14.0002 13.0021 11.3134 13.0021 7.99911C13.0021 6.22179 12.2295 4.62494 11.0018 3.5261" stroke="currentColor" stroke-width="2"/>
+<path d="M15.8453 4.72101L11.0039 2.79688L9.07977 7.63828" stroke="currentColor" stroke-width="2"/>
+</svg>

--- a/src/components/icons/RelaySmall.svg
+++ b/src/components/icons/RelaySmall.svg
@@ -1,0 +1,7 @@
+<svg width="22" height="14" viewBox="0 0 22 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect y="9" width="4" height="2" fill="currentColor"/>
+<rect x="18" y="9" width="4" height="2" fill="currentColor"/>
+<circle cx="5.81826" cy="9.94716" r="2.55263" stroke="currentColor" stroke-width="2"/>
+<circle cx="16.1854" cy="9.94716" r="2.55263" stroke="currentColor" stroke-width="2"/>
+<path d="M6.5 8.5L12.5 1.5" stroke="currentColor" stroke-width="2"/>
+</svg>

--- a/src/components/icons/TrashSmall.svg
+++ b/src/components/icons/TrashSmall.svg
@@ -1,0 +1,7 @@
+<svg width="17" height="19" viewBox="0 0 17 19" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M14.1736 5.70703V16.8132C14.1736 17.4339 13.6743 17.9429 13.0654 17.9429H3.9871C3.37822 17.9429 2.87891 17.4339 2.87891 16.8132V5.70703" stroke="currentColor" stroke-width="2" stroke-miterlimit="10"/>
+<path d="M16.0543 5.25586H11.4846H5.52218H0.917969" stroke="currentColor" stroke-width="2" stroke-miterlimit="10"/>
+<path d="M5.70312 5.7063V2.80616C5.70312 2.32966 5.99635 1.94141 6.28958 1.94141H10.8527C11.1459 1.94141 11.3505 2.3326 11.3505 2.80616V5.7063" stroke="currentColor" stroke-width="2" stroke-miterlimit="10"/>
+<path d="M6.64062 7.58789V15.1177" stroke="currentColor" stroke-width="2" stroke-miterlimit="10"/>
+<path d="M10.4062 7.58789V15.1177" stroke="currentColor" stroke-width="2" stroke-miterlimit="10"/>
+</svg>


### PR DESCRIPTION
Some fixing up of these settings pages to match the other pages. Added in missing icons: 

![settings page](https://user-images.githubusercontent.com/1589186/123176706-cf883780-d438-11eb-9ef6-539fe1732edf.png) ![relay settings](https://user-images.githubusercontent.com/1589186/123176710-d020ce00-d438-11eb-94f2-fea9482dca00.png)
