### PR TITLE
fix: default to write in edit/add contact, and put contact's exiting …

### DIFF
--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -24,7 +24,9 @@ type Props = {
 };
 
 export default function Contact({ contactId, backHref }: Props) {
-  let [contact, setContact] = useState<IContact>(backchannel.db.getContactById(contactId));
+  let [contact, setContact] = useState<IContact>(
+    backchannel.db.getContactById(contactId)
+  );
   let [nickname, setNickname] = useState<string>(contact.moniker);
   let [tab, setTab] = useState<Tab>(Tab.Write);
   let [errorMsg, setErrorMsg] = useState('');


### PR DESCRIPTION
This also makes sure that when you edit a contact, it is auto-populated with the name it currently is so it is clear which contact you are renaming.

![Screen Shot 2021-06-24 at 12 06 30 PM](https://user-images.githubusercontent.com/633012/123318943-a02f0480-d4e4-11eb-9c00-94d34ef8c5cb.png)
